### PR TITLE
Fix a few parser edge cases triggered by OpenBLAS

### DIFF
--- a/package_test.go
+++ b/package_test.go
@@ -51,3 +51,12 @@ func Test_CommentParsing(t *testing.T) {
 	require.Equal(t, pkg.Version, "2.10")
 	require.Equal(t, pkg.URL, "http://www.oberhumer.com/opensource/lzo/")
 }
+
+func Test_LoadOpenBLAS(t *testing.T) {
+	pkg, err := Load("testdata/openblas.pc")
+	require.NoError(t, err)
+
+	require.Equal(t, pkg.Name, "openblas")
+	require.Equal(t, pkg.Description, "OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version")
+	require.Equal(t, pkg.Version, "0.3.23")
+}

--- a/parser.go
+++ b/parser.go
@@ -124,6 +124,7 @@ func matchWhitespace(s *goparsify.State) {
 	}
 }
 
+//nolint:unparam
 func (pkg *Package) replaceVariables(input string) (string, error) {
 	mutatedInput := input
 

--- a/parser.go
+++ b/parser.go
@@ -43,13 +43,13 @@ var (
 
 	key                = goparsify.Chars("a-zA-Z0-9_.")
 	value              = goparsify.NotChars("\n").Map(func(n *goparsify.Result) { n.Result = n.Token })
-	variableAssignment = goparsify.Seq(key, "=", value).Map(func(n *goparsify.Result) {
+	variableAssignment = goparsify.Seq(key, "=", goparsify.Maybe(value)).Map(func(n *goparsify.Result) {
 		n.Result = Variable{
 			Key:   n.Child[0].Token,
 			Value: n.Child[2].Token,
 		}
 	})
-	propertyAssignment = goparsify.Seq(key, goparsify.Cut(), ":", value).Map(func(n *goparsify.Result) {
+	propertyAssignment = goparsify.Seq(key, goparsify.Cut(), ":", goparsify.Maybe(value)).Map(func(n *goparsify.Result) {
 		key := strings.ToTitle(n.Child[0].Token)
 		value := n.Child[3].Token
 

--- a/testdata/openblas.pc
+++ b/testdata/openblas.pc
@@ -1,0 +1,13 @@
+libdir=/usr/lib
+libsuffix=
+includedir=/usr/include
+openblas_config= USE_64BITINT= DYNAMIC_ARCH=1 DYNAMIC_OLDER= NO_CBLAS= NO_LAPACK= NO_LAPACKE= NO_AFFINITY=1 USE_OPENMP=0 CORE2 MAX_THREADS=256
+version=0.3.23
+extralib=-lm -lpthread -lgfortran -lm -lpthread -lgfortran
+Name: openblas
+Description: OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version
+Version: ${version}
+URL: https://github.com/xianyi/OpenBLAS
+Libs: -L${libdir} -lopenblas${libsuffix}
+Libs.private: ${extralib}
+Cflags: -I${includedir}


### PR DESCRIPTION
OpenBLAS has two things previously unaccounted for in our parser:

- Empty variable assignment (`libversion=\n`)
- Version as variable (`Version: ${version}\n`)