### PR TITLE
add test for python 3.11

### DIFF
--- a/package_test.go
+++ b/package_test.go
@@ -60,3 +60,11 @@ func Test_LoadOpenBLAS(t *testing.T) {
 	require.Equal(t, pkg.Description, "OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version")
 	require.Equal(t, pkg.Version, "0.3.23")
 }
+
+func Test_LoadPython(t *testing.T) {
+	pkg, err := Load("testdata/python-3.11.pc")
+	require.NoError(t, err)
+
+	require.Equal(t, pkg.Name, "Python")
+	require.Equal(t, pkg.Version, "3.11")
+}

--- a/testdata/python-3.11.pc
+++ b/testdata/python-3.11.pc
@@ -1,0 +1,13 @@
+# See: man pkg-config
+prefix=/usr
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+
+Name: Python
+Description: Build a C extension for Python
+Requires:
+Version: 3.11
+Libs.private: -ldl 
+Libs:
+Cflags: -I${includedir}/python3.11


### PR DESCRIPTION
Add regression test to make sure that `python-3.11.pc` is loadable.