### PR TITLE
Bug: vermatch order make >= unmatchable

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -67,7 +67,7 @@ var (
 	verEqual            = goparsify.Exact("=").Map(func(n *goparsify.Result) { n.Result = VersionEqual })
 	verGreaterThanEqual = goparsify.Exact(">").Map(func(n *goparsify.Result) { n.Result = VersionGreaterThanEqual })
 	verGreaterThan      = goparsify.Exact(">=").Map(func(n *goparsify.Result) { n.Result = VersionGreaterThan })
-	verMatch            = goparsify.Any(verLessThanEqual, verLessThan, verEqual, verGreaterThan, verGreaterThanEqual)
+	verMatch            = goparsify.Any(verLessThanEqual, verLessThan, verEqual, verGreaterThanEqual, verGreaterThan)
 
 	dependencyChain = goparsify.Seq(identifier, verMatch, version)
 	dependency      = goparsify.Any(dependencyChain, identifier)


### PR DESCRIPTION
The order in verMatch makes >= unmatchable. goparsify.Any tries alternatives in order and returns the first match. The order is:

```
verMatch = goparsify.Any(verLessThanEqual, verLessThan, verEqual, verGreaterThan, verGreaterThanEqual)
```

When the input is >=, the parser tries verGreaterThan first (which matches >) and returns immediately consuming only the > and leaving = unmatched. verGreaterThanEqual (>=) never gets tried.

I hit an issue with Melange https://github.com/chainguard-dev/melange/issues/2137 due to this.

So freetype2 >= 9.8.3 in gd-dev's .pc file gets parsed as freetype2 > 9.8.3 with a leftover = causing a parse error or wrong comparison, which then makes the solver reject freetype2 at version 26.2.20 even though it clearly satisfies the constraint.
