### PR TITLE
fix(ci): add zizmor pedantic persona and suppress noisy findings

### DIFF
--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -9,11 +9,15 @@ on:
     paths:
       - '.github/workflows/**'
       - '.github/actions/**'
+      - '.github/dependabot.yml'
+      - '.github/zizmor.yml'
   push:
     branches: ['main']
     paths:
       - '.github/workflows/**'
       - '.github/actions/**'
+      - '.github/dependabot.yml'
+      - '.github/zizmor.yml'
 
 permissions: {}
 
@@ -42,3 +46,5 @@ jobs:
 
       - name: Run zizmor
         uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
+        with:
+          persona: pedantic

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,18 @@
+# Copyright 2026 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Zizmor configuration for go-pkgconfig.
+# CI runs zizmor with --pedantic; rules with no security value are disabled
+# to keep CI signal-to-noise high. See PSEC-923 for rationale.
+
+rules:
+  dependabot-cooldown:
+    config:
+      days: 3
+  # Pedantic-only; no security impact — cosmetic/style findings
+  anonymous-definition:
+    disable: true
+  # Pedantic-only; low security value but extremely noisy
+  # Address concurrency limits as a separate, dedicated effort if desired
+  concurrency-limits:
+    disable: true


### PR DESCRIPTION

## Summary

This single-patch series adds the `persona: pedantic` configuration to the
zizmor CI workflow and suppresses noisy pedantic-only rules with no direct
security value. The `dependabot-cooldown` rule is configured to accept the
existing 3-day cooldown already present in `dependabot.yml`.

## Patches

### 0001 — fix(ci): add pedantic persona and suppress noisy zizmor rules

Adds `.github/zizmor.yml` with the following configuration:

- `dependabot-cooldown: config: days: 3` — tells zizmor to accept the
  existing `default-days: 3` in `dependabot.yml` (2 findings resolved;
  zizmor's default threshold is 7 days)
- `anonymous-definition: disable: true` — pedantic-only, purely cosmetic
  (1 finding suppressed)
- `concurrency-limits: disable: true` — pedantic-only, low security value
  (4 findings suppressed)

Note: `dependabot.yml` already has `cooldown: default-days: 3` for both
the github-actions and gomod ecosystems; no changes to `dependabot.yml`
are needed.

Updates `.github/workflows/zizmor.yaml` to:
- Pass `--pedantic` to zizmor-action
- Extend the `paths:` trigger to include `.github/dependabot.yml` and
  `.github/zizmor.yml`

## Findings addressed

| Rule | Count | Disposition |
|------|-------|-------------|
| `concurrency-limits` | 4 | Disabled in zizmor.yml (low security value) |
| `dependabot-cooldown` | 2 | Resolved by days: 3 config in zizmor.yml |
| `anonymous-definition` | 1 | Disabled in zizmor.yml (no security impact) |

## Testing

After merging, open a PR that modifies `.github/zizmor.yml` to verify the
paths trigger fires. The zizmor check should pass with zero findings.

Refs: PSEC-923